### PR TITLE
Fix script paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-project-root/scripts/shopify_backup.json
+scripts/shopify_backup.json
 # Python caches
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository contains tools to update Shopify variant prices and now includes
 
 ## Using the Updaters
 
-- **Percentage Updater** adjusts prices by a percentage and uses `project-root/scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs.
+- **Percentage Updater** adjusts prices by a percentage and uses `scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs.
 - **Variant Updater** runs `tempo solution/update_prices.py`. The page shows all surcharges from `tempo solution/variant_prices.json`. Edit the values for each chain and click **Save Changes** to update the file. Then use the **Run Update** button to apply the prices while the real-time log streams.
 
 The output from each script is streamed live to your browser so you can follow progress.
@@ -35,7 +35,7 @@ The output from each script is streamed live to your browser so you can follow p
 
 When `update_prices_shopify.py` runs for the first time it downloads every
 variant price from Shopify and stores them in a file named
-`shopify_backup.json` under `project-root/scripts/`. This allows
+`shopify_backup.json` under `scripts/`. This allows
 `reset_prices_shopify.py` to restore the original prices later.  The backup can
 grow to around **500&nbsp;KB** depending on the number of variants, so it is now
 ignored by Git and will be recreated whenever needed.

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -4,7 +4,7 @@ import subprocess, os, json
 main_bp = Blueprint('main', __name__)
 
 SCRIPTS = {
-    'percentage': os.path.join('project-root', 'scripts', 'update_prices_shopify.py'),
+    'percentage': os.path.join('scripts', 'update_prices_shopify.py'),
     'variant': os.path.join('tempo solution', 'update_prices.py')
 }
 


### PR DESCRIPTION
## Summary
- point README usage docs at scripts/update_prices_shopify.py
- ignore the correct Shopify backup file
- update web UI to call scripts/update_prices_shopify.py

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_68503f0997c0832c9c685a93cb37d857