### PR TITLE
Fix ruff config lint table

### DIFF
--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,4 +1,5 @@
 # Generic, formatter-friendly config.
+[lint]
 select = ["B", "D3", "E", "F"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.


### PR DESCRIPTION
## Summary
- move `select` and `ignore` options into `[lint]` table for ruff

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_6850465d1900832c9275082e63b3465d