### PR TITLE
Fix CSRF token fields

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,3 +25,9 @@ def test_login_with_default_credentials(client):
     resp = client.post('/login', data={'username': 'admin', 'password': 'password'}, follow_redirects=True)
     assert resp.status_code == 200
     assert b'Welcome' in resp.data
+
+
+def test_login_form_contains_csrf(client):
+    resp = client.get('/login')
+    assert resp.status_code == 200
+    assert b'<input type="hidden" name="csrf_token"' in resp.data

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -4,7 +4,7 @@
   <div class="col-md-4">
     <h3 class="mb-3">Login</h3>
     <form method="post">
-      {{ csrf_token() }}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3">
         <input class="form-control" type="text" name="username" placeholder="Username" required>
       </div>

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h3>Variant Price Update</h3>
 <form method="post">
-  {{ csrf_token() }}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% for cat, chains in surcharges.items() %}
   <h5 class="mt-3">{{ cat|capitalize }}</h5>
   {% for chain, val in chains.items() %}


### PR DESCRIPTION
## Summary
- ensure CSRF token included in login and variant forms
- test login page for CSRF field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'webapp')*

------
https://chatgpt.com/codex/tasks/task_e_68504b20c534832cb747aa22e89d2bf6