### PR TITLE
Add reset functionality to web UI

### DIFF
--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -17,7 +17,8 @@ main_bp = Blueprint('main', __name__)
 
 SCRIPTS = {
     'percentage': os.path.join('scripts', 'update_prices_shopify.py'),
-    'variant': os.path.join('tempo solution', 'update_prices.py')
+    'variant': os.path.join('tempo solution', 'update_prices.py'),
+    'reset': os.path.join('scripts', 'reset_prices_shopify.py')
 }
 
 
@@ -89,4 +90,11 @@ def stream_percentage():
 @login_required
 def stream_variant():
     cmd = ['python3', SCRIPTS['variant']]
+    return Response(stream_job(cmd), mimetype='text/event-stream')
+
+
+@main_bp.route('/stream/reset')
+@login_required
+def stream_reset():
+    cmd = ['python3', SCRIPTS['reset']]
     return Response(stream_job(cmd), mimetype='text/event-stream')

--- a/webapp/templates/percentage.html
+++ b/webapp/templates/percentage.html
@@ -5,6 +5,7 @@
   <input id="percent" class="form-control" type="number" step="0.01" placeholder="Enter percentage">
 </div>
 <button id="start" class="btn btn-brand">Run</button>
+<button id="reset" class="btn btn-secondary ms-2">Reset</button>
 <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
 <div id="status" class="alert alert-success d-none mt-2"></div>
@@ -12,6 +13,7 @@
 {% block scripts %}
 <script>
   const startBtn = document.getElementById('start');
+  const resetBtn = document.getElementById('reset');
   const spinner = document.getElementById('spinner');
   const status = document.getElementById('status');
   startBtn.onclick = function(){
@@ -28,6 +30,29 @@
         spinner.classList.add('d-none');
         startBtn.disabled = false;
         status.textContent = 'Update completed!';
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\n';
+      }
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+
+  resetBtn.onclick = function(){
+    const log = document.getElementById('log');
+    log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
+    resetBtn.disabled = true;
+    const es = new EventSource('/stream/reset');
+    es.onmessage = e => {
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        resetBtn.disabled = false;
+        status.textContent = 'Reset completed!';
         status.classList.remove('d-none');
       } else {
         log.textContent += e.data + '\n';


### PR DESCRIPTION
## Summary
- add a new `/stream/reset` endpoint
- expose price reset script in `SCRIPTS`
- show a *Reset* button in the Percentage updater page to run the restore script

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685051928578832cb29c640b26bea116