### PR TITLE
Improve updater UI

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -40,16 +40,25 @@
   </div>
 </nav>
 <div class="container py-4">
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        {% for category, msg in messages %}
-          <div class="alert alert-{{ 'danger' if category == 'error' else category }}">{{ msg }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
     {% block content %}{% endblock %}
 </div>
+
+<div class="toast-container position-fixed top-0 end-0 p-3">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% for category, msg in messages %}
+        <div class="toast align-items-center text-bg-{{ 'danger' if category == 'error' else category }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="d-flex">
+            <div class="toast-body">{{ msg }}</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+          </div>
+        </div>
+      {% endfor %}
+    {% endwith %}
+</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  document.querySelectorAll('.toast').forEach(t => new bootstrap.Toast(t).show());
+</script>
 {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -1,9 +1,24 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Welcome</h3>
-<p>Select an action:</p>
-<ul>
-  <li><a href="{{ url_for('main.percentage_updater') }}">Percentage Updater</a></li>
-  <li><a href="{{ url_for('main.variant_updater') }}">Variant Updater</a></li>
-</ul>
+<h3 class="mb-4">Welcome</h3>
+<div class="row g-4">
+  <div class="col-md-6">
+    <div class="card shadow-sm h-100">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">Percentage Price Update</h5>
+        <p class="card-text flex-grow-1">Adjust all prices by a percentage.</p>
+        <a class="btn btn-brand mt-auto" href="{{ url_for('main.percentage_updater') }}">Open</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card shadow-sm h-100">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">Variant Price Update</h5>
+        <p class="card-text flex-grow-1">Edit surcharges for each chain and run the updater.</p>
+        <a class="btn btn-brand mt-auto" href="{{ url_for('main.variant_updater') }}">Open</a>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/webapp/templates/percentage.html
+++ b/webapp/templates/percentage.html
@@ -7,6 +7,9 @@
 <button id="start" class="btn btn-brand">Run</button>
 <button id="reset" class="btn btn-secondary ms-2">Reset</button>
 <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+<div id="progress" class="progress mt-2 d-none">
+  <div class="progress-bar progress-bar-striped progress-bar-animated" style="width:100%"></div>
+</div>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
 <div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
@@ -15,19 +18,23 @@
   const startBtn = document.getElementById('start');
   const resetBtn = document.getElementById('reset');
   const spinner = document.getElementById('spinner');
+  const progress = document.getElementById('progress');
   const status = document.getElementById('status');
   startBtn.onclick = function(){
+    if(!confirm('Run percentage update?')) return;
     const p = document.getElementById('percent').value;
     const log = document.getElementById('log');
     log.textContent='';
     status.classList.add('d-none');
     spinner.classList.remove('d-none');
+    progress.classList.remove('d-none');
     startBtn.disabled = true;
     const es = new EventSource(`/stream/percentage?percent=${encodeURIComponent(p)}`);
     es.onmessage = e => {
       if(e.data === '--done--') {
         es.close();
         spinner.classList.add('d-none');
+        progress.classList.add('d-none');
         startBtn.disabled = false;
         status.textContent = 'Update completed!';
         status.classList.remove('d-none');
@@ -39,10 +46,12 @@
   };
 
   resetBtn.onclick = function(){
+    if(!confirm('Reset all prices using backup?')) return;
     const log = document.getElementById('log');
     log.textContent='';
     status.classList.add('d-none');
     spinner.classList.remove('d-none');
+    progress.classList.remove('d-none');
     startBtn.disabled = true;
     resetBtn.disabled = true;
     const es = new EventSource('/stream/reset');
@@ -50,6 +59,7 @@
       if(e.data === '--done--') {
         es.close();
         spinner.classList.add('d-none');
+        progress.classList.add('d-none');
         startBtn.disabled = false;
         resetBtn.disabled = false;
         status.textContent = 'Reset completed!';

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -1,23 +1,31 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Variant Price Update</h3>
-<form method="post">
+<form method="post" onsubmit="return confirm('Save updated surcharges?')">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% for cat, chains in surcharges.items() %}
-  <h5 class="mt-3">{{ cat|capitalize }}</h5>
-  {% for chain, val in chains.items() %}
-  <div class="mb-2 row g-2 align-items-center">
-    <label class="col-sm-4 col-form-label">{{ chain }}</label>
-    <div class="col-sm-4">
-      <input class="form-control" type="number" step="0.01" name="{{ cat }}_{{ chain.replace(' ', '_') }}" value="{{ val }}">
-    </div>
-  </div>
-  {% endfor %}
+  <h5 class="mt-4">{{ cat|capitalize }}</h5>
+  <table class="table table-striped align-middle">
+    <thead><tr><th>Chain</th><th>Surcharge (€)</th></tr></thead>
+    <tbody>
+    {% for chain, val in chains.items() %}
+    <tr>
+      <td>{{ chain }}</td>
+      <td style="max-width:200px">
+        <input class="form-control" type="number" step="0.01" name="{{ cat }}_{{ chain.replace(' ', '_') }}" value="{{ val }}">
+      </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
   {% endfor %}
   <button class="btn btn-brand mt-2" type="submit">Save Changes</button>
 </form>
 <button id="start" class="btn btn-brand mt-3">Run Update</button>
 <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+<div id="progress" class="progress mt-2 d-none">
+  <div class="progress-bar progress-bar-striped progress-bar-animated" style="width:100%"></div>
+</div>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
 <div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
@@ -25,18 +33,22 @@
 <script>
   const startBtn = document.getElementById('start');
   const spinner = document.getElementById('spinner');
+  const progress = document.getElementById('progress');
   const status = document.getElementById('status');
   startBtn.onclick = function(){
+    if(!confirm('Run variant update?')) return;
     const log = document.getElementById('log');
     log.textContent='';
     status.classList.add('d-none');
     spinner.classList.remove('d-none');
+    progress.classList.remove('d-none');
     startBtn.disabled = true;
     const es = new EventSource('/stream/variant');
     es.onmessage = e => {
       if(e.data === '--done--') {
         es.close();
         spinner.classList.add('d-none');
+        progress.classList.add('d-none');
         startBtn.disabled = false;
         status.textContent = 'Update completed!';
         status.classList.remove('d-none');


### PR DESCRIPTION
## Summary
- modernize the home dashboard with Bootstrap cards
- show flash messages as Bootstrap toasts
- confirm updater actions and show progress bars
- reformat the variant updater into tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685055201a08832c8bcc158beb1e86f7