### PR TITLE
Refine UI and integrate reset action

### DIFF
--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -67,6 +67,7 @@ def variant_updater():
     return render_template('variant.html', surcharges=surcharges)
 
 
+
 def stream_job(cmd):
     job_id = enqueue(cmd)
 

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,23 +1,39 @@
 :root {
-    --primary-color: #b8860b;
-    --dark-color: #3b2c20;
-    --light-bg: #f9f8f6;
+    --primary-color: #4B343B;
+    --secondary-color: #6C5158;
+    --accent-color: #D4A3A6;
+    --highlight-color: #EDE5E5;
+    --neutral-dark: #333333;
+    --neutral-light: #F7F7F7;
 }
 
 body {
-    font-family: 'Poppins', 'Inter', sans-serif;
-    background: linear-gradient(135deg, var(--light-bg), #f0e8d9);
-    color: #212529;
+    font-family: 'Montserrat', 'Poppins', sans-serif;
+    background: linear-gradient(135deg, var(--neutral-light), var(--highlight-color));
+    color: var(--neutral-dark);
     min-height: 100vh;
 }
 
 .navbar {
     background: #ffffff;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--highlight-color);
 }
 
 .navbar-brand img {
-    height: 40px;
+    height: 45px;
+}
+
+.nav-link {
+    color: var(--primary-color) !important;
+}
+
+.nav-link:hover {
+    color: var(--secondary-color) !important;
+}
+
+.nav-link.active {
+    font-weight: 600;
 }
 
 .btn-brand {
@@ -25,6 +41,12 @@ body {
     border: none;
     color: #fff;
     transition: opacity 0.2s ease;
+}
+
+.btn-secondary {
+    background: var(--secondary-color);
+    border: none;
+    color: #fff;
 }
 
 .btn-brand:hover {
@@ -35,21 +57,25 @@ body {
     border: none;
     border-radius: 0.5rem;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    background: var(--highlight-color);
 }
 
 .service-card {
-    transition: transform 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .service-card:hover {
     transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
 }
 
-.table thead {
-    background: var(--dark-color);
-    color: #fff;
+#log {
+    background: var(--highlight-color);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 0.25rem;
+    padding: 0.75rem;
 }
 
-.table-striped tbody tr:nth-of-type(odd) {
-    background-color: rgba(0, 0, 0, 0.02);
+.spinner-border.text-primary {
+    color: var(--primary-color);
 }

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -4,21 +4,21 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-9lw2gfbzXGBw64frtB54HuZk7sP6/Iex9jYYmZC9U1E4Yzmyd2zh1SeDsICoZ6irMIXgYYWf0iD98s+DAaYEiw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <title>Azor Price Updater</title>
-    <style>
-        body { background-color: #f8f9fa; }
-        .navbar { background-color: #343a40; }
-        .navbar-brand, .nav-link, .navbar-text { color: #fff !important; }
-        .nav-link.active { font-weight: bold; }
-        .btn-brand { background-color: #008cba; color: #fff; }
-        h3, h5 { margin-top: 1rem; }
-    </style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
-    <a class="navbar-brand" href="/">Azor Updater</a>
-    <div class="collapse navbar-collapse">
+    <a class="navbar-brand d-flex align-items-center" href="{{ url_for('main.home') }}">
+      <img src="{{ url_for('static', filename='assets/logo/473718710_1348387132818131_72892133825066643_n-removebg-preview_1.png') }}" alt="Azor logo" class="me-2">
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
       {% if session.get('user') %}
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
@@ -32,8 +32,13 @@
         </li>
       </ul>
       <ul class="navbar-nav ms-auto">
-        <li class="nav-item"><span class="navbar-text me-3">Logged in as {{ session['user'] }}</span></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
+        <li class="nav-item d-flex align-items-center me-3">
+          <i class="fa-solid fa-user me-1"></i>
+          <span class="navbar-text">{{ session['user'] }}</span>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-right-from-bracket me-1"></i>Logout</a>
+        </li>
       </ul>
       {% endif %}
     </div>

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -1,9 +1,24 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Welcome</h3>
-<p>Select an action:</p>
-<ul>
-  <li><a href="{{ url_for('main.percentage_updater') }}">Percentage Updater</a></li>
-  <li><a href="{{ url_for('main.variant_updater') }}">Variant Updater</a></li>
-</ul>
+<h3 class="mb-4">Welcome</h3>
+<div class="row g-4">
+  <div class="col-md-6 col-lg-4">
+    <a href="{{ url_for('main.percentage_updater') }}" class="text-decoration-none text-reset">
+      <div class="card service-card h-100 text-center p-4">
+        <i class="fa-solid fa-percent fa-2x mb-3"></i>
+        <h5 class="card-title">Percentage Price Updater</h5>
+        <p class="card-text small">Adjust all product prices by a percentage.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-md-6 col-lg-4">
+    <a href="{{ url_for('main.variant_updater') }}" class="text-decoration-none text-reset">
+      <div class="card service-card h-100 text-center p-4">
+        <i class="fa-solid fa-gears fa-2x mb-3"></i>
+        <h5 class="card-title">Variant Price Updater</h5>
+        <p class="card-text small">Update variant surcharges individually.</p>
+      </div>
+    </a>
+  </div>
+</div>
 {% endblock %}

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -2,18 +2,24 @@
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-md-4">
-    <h3 class="mb-3">Login</h3>
+    <h3 class="mb-3 text-center">Login</h3>
     <form method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div class="mb-3">
+      <div class="mb-3 input-group">
+        <span class="input-group-text"><i class="fa-solid fa-user"></i></span>
         <input class="form-control" type="text" name="username" placeholder="Username" required>
       </div>
-      <div class="mb-3">
-        <input class="form-control" type="password" name="password" placeholder="Password" required>
+      <div class="mb-3 input-group">
+        <span class="input-group-text"><i class="fa-solid fa-lock"></i></span>
+        <input class="form-control" id="password" type="password" name="password" placeholder="Password" required>
+        <button class="btn btn-outline-secondary" type="button" id="togglePass"><i class="fa-solid fa-eye"></i></button>
       </div>
       {% if error %}<div class="text-danger mb-2">{{ error }}</div>{% endif %}
-      <button class="btn btn-brand" type="submit">Login</button>
+      <button class="btn btn-brand w-100" type="submit">Login</button>
     </form>
   </div>
 </div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='script.js') }}"></script>
 {% endblock %}

--- a/webapp/templates/percentage.html
+++ b/webapp/templates/percentage.html
@@ -1,13 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Percentage Price Update</h3>
-<div class="mb-3">
-  <input id="percent" class="form-control" type="number" step="0.01" placeholder="Enter percentage">
+<h3 class="mb-3"><i class="fa-solid fa-percent me-2"></i>Percentage Price Update</h3>
+<div class="mb-3 row g-2 align-items-center">
+  <div class="col-sm-4">
+    <input id="percent" class="form-control" type="number" step="0.01" placeholder="Enter percentage">
+  </div>
+  <div class="col-auto">
+    <button id="start" class="btn btn-brand">Run</button>
+    <button id="reset" class="btn btn-secondary ms-2">Reset</button>
+    <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+  </div>
 </div>
-<button id="start" class="btn btn-brand">Run</button>
-<button id="reset" class="btn btn-secondary ms-2">Reset</button>
-<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
-<pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+<pre id="log" class="mt-3" style="height:300px;overflow:auto;"></pre>
 <div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
 {% block scripts %}

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3>Variant Price Update</h3>
-<form method="post">
+<h3 class="mb-3"><i class="fa-solid fa-gears me-2"></i>Variant Price Update</h3>
+<form method="post" class="mb-3">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% for cat, chains in surcharges.items() %}
   <h5 class="mt-3">{{ cat|capitalize }}</h5>
@@ -16,9 +16,9 @@
   {% endfor %}
   <button class="btn btn-brand mt-2" type="submit">Save Changes</button>
 </form>
-<button id="start" class="btn btn-brand mt-3">Run Update</button>
+<button id="start" class="btn btn-brand">Run Update</button>
 <div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
-<pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+<pre id="log" class="mt-3" style="height:300px;overflow:auto;"></pre>
 <div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- apply new burgundy/blush color palette and Montserrat font
- tidy navigation and remove dedicated reset page
- keep reset functionality as a button on the percentage page

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685079804d1c832cb442b2e4107f1ed0