### PR TITLE
Add password toggle icon change

### DIFF
--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,9 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('togglePass');
+    const icon = toggle ? toggle.querySelector('i') : null;
+
     if (toggle) {
         toggle.addEventListener('click', () => {
             const pass = document.getElementById('password');
-            if (pass) pass.type = pass.type === 'password' ? 'text' : 'password';
+            if (!pass) return;
+
+            const isHidden = pass.type === 'password';
+            pass.type = isHidden ? 'text' : 'password';
+
+            if (icon) {
+                icon.classList.toggle('fa-eye', !isHidden);
+                icon.classList.toggle('fa-eye-slash', isHidden);
+            }
         });
     }
 });


### PR DESCRIPTION
## Summary
- tweak login JS to swap eye icon when showing password

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850895d4118832c81ae1b362ef380a9