### PR TITLE
Add language toggle

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, g, session
 from flask_wtf import CSRFProtect
 from dotenv import load_dotenv
 import os
@@ -16,5 +16,28 @@ def create_app():
     from .routes import main_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
+
+    @app.before_request
+    def set_language():
+        g.lang = session.get('lang', 'en')
+
+    @app.context_processor
+    def inject_translator():
+        translations = {
+            'home': {'en': 'Home', 'fr': 'Accueil'},
+            'percentage': {'en': 'Percentage', 'fr': 'Pourcentage'},
+            'variant': {'en': 'Variant', 'fr': 'Variante'},
+            'logout': {'en': 'Logout', 'fr': 'Déconnexion'},
+            'language': {'en': 'Français', 'fr': 'English'},
+            'login': {'en': 'Login', 'fr': 'Connexion'},
+            'username': {'en': 'Username', 'fr': "Nom d'utilisateur"},
+            'password': {'en': 'Password', 'fr': 'Mot de passe'},
+        }
+
+        def t(key):
+            lang = g.get('lang', 'en')
+            return translations.get(key, {}).get(lang, key)
+
+        return dict(t=t)
 
     return app

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -15,6 +15,13 @@ from .jobqueue import enqueue, stream
 
 main_bp = Blueprint('main', __name__)
 
+
+@main_bp.route('/toggle-language')
+def toggle_language():
+    current = session.get('lang', 'en')
+    session['lang'] = 'fr' if current == 'en' else 'en'
+    return redirect(request.referrer or url_for('main.home'))
+
 SCRIPTS = {
     'percentage': os.path.join('scripts', 'update_prices_shopify.py'),
     'variant': os.path.join('tempo solution', 'update_prices.py'),

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,9 +1,20 @@
 document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('togglePass');
+    const openIcon = toggle ? toggle.querySelector('.eye-open') : null;
+    const closedIcon = toggle ? toggle.querySelector('.eye-closed') : null;
+
     if (toggle) {
         toggle.addEventListener('click', () => {
             const pass = document.getElementById('password');
-            if (pass) pass.type = pass.type === 'password' ? 'text' : 'password';
+            if (!pass) return;
+
+            const isHidden = pass.type === 'password';
+            pass.type = isHidden ? 'text' : 'password';
+
+            if (openIcon && closedIcon) {
+                openIcon.classList.toggle('d-none', !isHidden);
+                closedIcon.classList.toggle('d-none', isHidden);
+            }
         });
     }
 });

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -79,3 +79,15 @@ body {
 .spinner-border.text-primary {
     color: var(--primary-color);
 }
+
+/* Simple inline SVG icons */
+.icon {
+    width: 1em;
+    height: 1em;
+    fill: currentColor;
+    vertical-align: -0.125em;
+}
+
+.d-none {
+    display: none !important;
+}

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ g.lang }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,28 +19,33 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-      {% if session.get('user') %}
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        {% if session.get('user') %}
         <li class="nav-item">
-          <a class="nav-link {{ 'active' if request.path == url_for('main.home') else '' }}" href="{{ url_for('main.home') }}">Home</a>
+          <a class="nav-link {{ 'active' if request.path == url_for('main.home') else '' }}" href="{{ url_for('main.home') }}">{{ t('home') }}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {{ 'active' if request.path == url_for('main.percentage_updater') else '' }}" href="{{ url_for('main.percentage_updater') }}">Percentage</a>
+          <a class="nav-link {{ 'active' if request.path == url_for('main.percentage_updater') else '' }}" href="{{ url_for('main.percentage_updater') }}">{{ t('percentage') }}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {{ 'active' if request.path == url_for('main.variant_updater') else '' }}" href="{{ url_for('main.variant_updater') }}">Variant</a>
+          <a class="nav-link {{ 'active' if request.path == url_for('main.variant_updater') else '' }}" href="{{ url_for('main.variant_updater') }}">{{ t('variant') }}</a>
         </li>
+        {% endif %}
       </ul>
       <ul class="navbar-nav ms-auto">
+        {% if session.get('user') %}
         <li class="nav-item d-flex align-items-center me-3">
           <i class="fa-solid fa-user me-1"></i>
           <span class="navbar-text">{{ session['user'] }}</span>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-right-from-bracket me-1"></i>Logout</a>
+          <a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-right-from-bracket me-1"></i>{{ t('logout') }}</a>
+        </li>
+        {% endif %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('main.toggle_language') }}">{{ t('language') }}</a>
         </li>
       </ul>
-      {% endif %}
     </div>
   </div>
 </nav>

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -3,22 +3,54 @@
 <div class="row justify-content-center">
   <div class="col-md-4">
 
-    <h3 class="mb-3 text-center"><i class="fa-solid fa-circle-user me-1"></i>Login</h3>
+    <h3 class="mb-3 text-center">
+      <svg class="icon me-1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" />
+        <circle cx="8" cy="5.5" r="3" />
+        <path d="M4 13c1.5-2 6-2 8 0" />
+      </svg>
+      {{ t('login') }}
+    </h3>
 
     <form method="post">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="mb-3 input-group">
-        <span class="input-group-text"><i class="fa-solid fa-user"></i></span>
-        <input class="form-control" type="text" name="username" placeholder="Username" required>
+        <span class="input-group-text">
+          <svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="8" cy="5" r="3" />
+            <path d="M2 14c0-3 4-5 6-5s6 2 6 5H2z" />
+          </svg>
+        </span>
+        <input class="form-control" type="text" name="username" placeholder="{{ t('username') }}" required>
       </div>
       <div class="mb-3 input-group">
-        <span class="input-group-text"><i class="fa-solid fa-lock"></i></span>
-        <input class="form-control" id="password" type="password" name="password" placeholder="Password" required>
-        <button class="btn btn-outline-secondary" type="button" id="togglePass"><i class="fa-solid fa-eye"></i></button>
+        <span class="input-group-text">
+          <svg class="icon" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="7" width="10" height="8" rx="2" />
+            <path d="M5 7V4a3 3 0 0 1 6 0v3" />
+          </svg>
+        </span>
+        <input class="form-control" id="password" type="password" name="password" placeholder="{{ t('password') }}" required>
+        <button class="btn btn-outline-secondary" type="button" id="togglePass">
+          <svg class="icon eye-open" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z" />
+            <circle cx="8" cy="8" r="2.5" />
+          </svg>
+          <svg class="icon eye-closed d-none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z" />
+            <circle cx="8" cy="8" r="2.5" />
+            <path d="M2 2l12 12" stroke-width="2" />
+          </svg>
+        </button>
       </div>
       {% if error %}<div class="text-danger mb-2">{{ error }}</div>{% endif %}
 
-      <button class="btn btn-brand w-100" type="submit"><i class="fa-solid fa-right-to-bracket me-1"></i>Login</button>
+      <button class="btn btn-brand w-100" type="submit">
+        <svg class="icon me-1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8 3l4 5-4 5M1 8h11" stroke="currentColor" stroke-width="2" fill="none" />
+        </svg>
+        {{ t('login') }}
+      </button>
 
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add before_request and context processor for language support
- implement /toggle-language route
- translate navbar and login form
- show current language in `<html>` tag

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850895d4118832c81ae1b362ef380a9