### PR TITLE
Handle Shopify API rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ required.
 
 ## Using the Updaters
 
-- **Percentage Updater** adjusts prices by a percentage and uses `scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs.
+- **Percentage Updater** adjusts prices by a percentage and uses `scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs. The script now retries automatically if the Shopify API responds with HTTP `429 Too Many Requests`.
 - **Variant Updater** runs `tempo solution/update_prices.py`. The page shows all surcharges from `tempo solution/variant_prices.json`. Edit the values for each chain and click **Save Changes** to update the file. Then use the **Run Update** button to apply the prices while the real-time log streams.
 
 The output from each script is streamed live to your browser so you can follow progress.


### PR DESCRIPTION
## Summary
- retry after a short delay when Shopify returns 429 in `update_prices_shopify.py`
- mention automatic retries in the README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850ec881258832c9db55647e7c518a4