### PR TITLE
Add base price initialization utility

### DIFF
--- a/scripts/init_base_price.py
+++ b/scripts/init_base_price.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import os
+import requests
+import time
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TOKEN = os.getenv("API_TOKEN")
+DOMAIN = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+
+
+def shopify_get(session, url, **kwargs):
+    """GET request with retry handling for Shopify rate limits."""
+    while True:
+        resp = session.get(url, **kwargs)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def graphql_post(session, query, variables=None):
+    """POST to Shopify GraphQL API with retry on 429."""
+    url = f"https://{DOMAIN}/admin/api/{API_VERSION}/graphql.json"
+    payload = {"query": query, "variables": variables or {}}
+    while True:
+        resp = session.post(url, json=payload)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def set_base_price(session, product_id, price):
+    mutation = """
+    mutation SetBase($mf: [MetafieldsSetInput!]!) {
+      metafieldsSet(metafields: $mf) {
+        userErrors { field message }
+      }
+    }
+    """
+    variables = {
+        "mf": [
+            {
+                "ownerId": f"gid://shopify/Product/{product_id}",
+                "namespace": "custom",
+                "key": "base_price",
+                "type": "number_decimal",
+                "value": str(price),
+            }
+        ]
+    }
+    resp = graphql_post(session, mutation, variables)
+    if resp.ok:
+        errors = resp.json()["data"]["metafieldsSet"]["userErrors"]
+        if errors:
+            for e in errors:
+                print(f"❌ base_price {product_id}: {e['message']}")
+        else:
+            print(f"✅ {product_id} → {price}")
+    else:
+        print(f"❌ base_price {product_id}: {resp.text}")
+
+
+def fetch_products(session):
+    base_url = f"https://{DOMAIN}/admin/api/{API_VERSION}"
+    products = []
+    page_info = None
+    while True:
+        params = {"limit": 250, "fields": "id,variants"}
+        if page_info:
+            params["page_info"] = page_info
+        resp = shopify_get(session, f"{base_url}/products.json", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        products.extend(data["products"])
+        link = resp.headers.get("Link", "")
+        if 'rel="next"' not in link:
+            break
+        page_info = link.split("page_info=")[1].split(">")[0]
+    return products
+
+
+def main():
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": TOKEN,
+        "Content-Type": "application/json",
+    })
+    print("🔄 Fetching products...")
+    products = fetch_products(session)
+    print(f"Found {len(products)} products")
+    for prod in products:
+        variants = prod.get("variants", [])
+        if not variants:
+            print(f"⚠️ No variants for product {prod['id']}")
+            continue
+        price = variants[0]["price"]
+        set_base_price(session, prod["id"], price)
+    print("🎉 Finished initializing base prices!")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -27,6 +27,11 @@ TRANSLATIONS = {
         'en': 'Update variant surcharges individually.',
         'fr': 'Mettre à jour chaque supplément de variante individuellement.'
     },
+    'base_price_card_title': {'en': 'Base Price Initialization', 'fr': 'Initialisation du prix de base'},
+    'base_price_card_desc': {
+        'en': "Set each product's base price to its current price.",
+        'fr': 'Définir le prix de base de chaque produit à son prix actuel.'
+    },
     'percentage_title': {'en': 'Percentage Price Update', 'fr': 'Mise à jour des prix par pourcentage'},
     'enter_percentage': {'en': 'Enter percentage', 'fr': 'Entrez le pourcentage'},
     'run': {'en': 'Run', 'fr': 'Exécuter'},
@@ -36,6 +41,7 @@ TRANSLATIONS = {
     'variant_title': {'en': 'Variant Price Update', 'fr': 'Mise à jour des prix des variantes'},
     'save_changes': {'en': 'Save Changes', 'fr': 'Enregistrer'},
     'run_update': {'en': 'Run Update', 'fr': 'Exécuter la mise à jour'},
+    'base_price_title': {'en': 'Base Price Initialization', 'fr': 'Initialisation du prix de base'},
     'price_reset_title': {'en': 'Price Reset', 'fr': 'Réinitialisation des prix'},
     'price_reset_intro': {
         'en': 'This will restore all prices from the last backup file.',

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -26,7 +26,8 @@ def toggle_language():
 SCRIPTS = {
     'percentage': os.path.join('scripts', 'update_prices_shopify.py'),
     'variant': os.path.join('tempo solution', 'update_prices.py'),
-    'reset': os.path.join('scripts', 'reset_prices_shopify.py')
+    'reset': os.path.join('scripts', 'reset_prices_shopify.py'),
+    'baseprice': os.path.join('scripts', 'init_base_price.py')
 }
 
 
@@ -75,6 +76,10 @@ def variant_updater():
     return render_template('variant.html', surcharges=surcharges)
 
 
+@main_bp.route('/base-price-init')
+@login_required
+def base_price_init():
+    return render_template('base_price.html')
 
 
 def stream_job(cmd):
@@ -100,6 +105,13 @@ def stream_percentage():
 @login_required
 def stream_variant():
     cmd = ['python3', SCRIPTS['variant']]
+    return Response(stream_job(cmd), mimetype='text/event-stream')
+
+
+@main_bp.route('/stream/base-price-init')
+@login_required
+def stream_base_price_init():
+    cmd = ['python3', SCRIPTS['baseprice']]
     return Response(stream_job(cmd), mimetype='text/event-stream')
 
 

--- a/webapp/templates/base_price.html
+++ b/webapp/templates/base_price.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3 class="mb-3"><i class="fa-solid fa-tag me-2"></i>{{ t('base_price_title') }}</h3>
+<button id="start" class="btn btn-brand">{{ t('run') }}</button>
+<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+<pre id="log" class="mt-3" style="height:300px;overflow:auto;"></pre>
+<div id="status" class="alert alert-success d-none mt-2"></div>
+{% endblock %}
+{% block scripts %}
+<script>
+  const startBtn = document.getElementById('start');
+  const spinner = document.getElementById('spinner');
+  const status = document.getElementById('status');
+  startBtn.onclick = function(){
+    const log = document.getElementById('log');
+    log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
+    const es = new EventSource('/stream/base-price-init');
+    es.onmessage = e => {
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        status.textContent = "{{ t('update_completed') }}";
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\\n';
+      }
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+</script>
+{% endblock %}

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -21,5 +21,14 @@
       </div>
     </a>
   </div>
+  <div class="col-md-6 col-lg-4">
+    <a href="{{ url_for('main.base_price_init') }}" class="text-decoration-none text-reset">
+      <div class="card service-card h-100 text-center p-4">
+        <i class="fa-solid fa-tag fa-2x mb-3"></i>
+        <h5 class="card-title">{{ t('base_price_card_title') }}</h5>
+        <p class="card-text small">{{ t('base_price_card_desc') }}</p>
+      </div>
+    </a>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add script to initialize Shopify custom base_price metafield with current prices
- expose /base-price-init route and SSE stream
- link base price initializer from dashboard with translations

## Testing
- `python -m py_compile scripts/init_base_price.py webapp/routes.py webapp/__init__.py`
- `WTF_CSRF_ENABLED=false PYTHONPATH=. pytest` *(fails: assert 400 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689f6caaf3108328ba25281830a0d202