### PR TITLE
Add base price initialization workflow and configurable CSRF

### DIFF
--- a/scripts/init_base_price.py
+++ b/scripts/init_base_price.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import os
+import time
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+TOKEN       = os.getenv("API_TOKEN")
+DOMAIN      = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+
+
+def shopify_get(session, url, **kwargs):
+    while True:
+        resp = session.get(url, **kwargs)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def graphql_post(session, query, variables=None):
+    url = f"https://{DOMAIN}/admin/api/{API_VERSION}/graphql.json"
+    payload = {"query": query, "variables": variables or {}}
+    while True:
+        resp = session.post(url, json=payload)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def set_base_price(session, product_id, price):
+    mutation = """
+    mutation SetBase($mf: [MetafieldsSetInput!]!) {
+      metafieldsSet(metafields: $mf) {
+        userErrors { field message }
+      }
+    }
+    """
+    variables = {
+        "mf": [
+            {
+                "ownerId": f"gid://shopify/Product/{product_id}",
+                "namespace": "custom",
+                "key": "base_price",
+                "type": "number_decimal",
+                "value": str(price),
+            }
+        ]
+    }
+    resp = graphql_post(session, mutation, variables)
+    if resp.ok:
+        errs = resp.json()["data"]["metafieldsSet"]["userErrors"]
+        if errs:
+            for e in errs:
+                print(f"❌ {product_id}: {e['message']}")
+        else:
+            print(f"✅ {product_id} → {price}")
+    else:
+        print(f"❌ {product_id}: {resp.text}")
+
+
+def main():
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": TOKEN,
+        "Content-Type": "application/json",
+    })
+
+    base_url = f"https://{DOMAIN}/admin/api/{API_VERSION}"
+    page_info = None
+    while True:
+        params = {"limit": 250}
+        if page_info:
+            params["page_info"] = page_info
+        resp = shopify_get(session, f"{base_url}/products.json", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        for prod in data.get("products", []):
+            price = prod["variants"][0]["price"]
+            set_base_price(session, prod["id"], price)
+        link = resp.headers.get("Link", "")
+        if 'rel="next"' not in link:
+            break
+        page_info = link.split("page_info=")[1].split(">")[0]
+    print("🎉 Finished initializing base prices!")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -27,6 +27,14 @@ TRANSLATIONS = {
         'en': 'Update variant surcharges individually.',
         'fr': 'Mettre à jour chaque supplément de variante individuellement.'
     },
+    'baseprice_card_title': {
+        'en': 'Base Price Initialization',
+        'fr': 'Initialisation du prix de base'
+    },
+    'baseprice_card_desc': {
+        'en': 'Create base_price metafield for all products.',
+        'fr': 'Créer le champ base_price pour tous les produits.'
+    },
     'percentage_title': {'en': 'Percentage Price Update', 'fr': 'Mise à jour des prix par pourcentage'},
     'enter_percentage': {'en': 'Enter percentage', 'fr': 'Entrez le pourcentage'},
     'run': {'en': 'Run', 'fr': 'Exécuter'},
@@ -48,6 +56,22 @@ TRANSLATIONS = {
         'en': 'Invalid value for {chain}',
         'fr': 'Valeur invalide pour {chain}'
     },
+    'baseprice_title': {
+        'en': 'Base Price Initialization',
+        'fr': 'Initialisation du prix de base'
+    },
+    'baseprice_intro': {
+        'en': 'Set each product\'s base_price metafield to its current price.',
+        'fr': 'Définir le champ base_price de chaque produit sur son prix actuel.'
+    },
+    'run_baseprice': {
+        'en': 'Run Initialization',
+        'fr': "Exécuter l'initialisation"
+    },
+    'baseprice_completed': {
+        'en': 'Initialization completed!',
+        'fr': 'Initialisation terminée !'
+    },
 }
 
 
@@ -63,6 +87,7 @@ def translate(key, lang=None, **kwargs):
 def create_app():
     app = Flask(__name__)
     app.secret_key = os.getenv('SECRET_KEY', 'change-me')
+    app.config['WTF_CSRF_ENABLED'] = os.getenv('WTF_CSRF_ENABLED', 'true').lower() == 'true'
     csrf.init_app(app)
 
     from .auth import auth_bp

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -26,7 +26,8 @@ def toggle_language():
 SCRIPTS = {
     'percentage': os.path.join('scripts', 'update_prices_shopify.py'),
     'variant': os.path.join('tempo solution', 'update_prices.py'),
-    'reset': os.path.join('scripts', 'reset_prices_shopify.py')
+    'reset': os.path.join('scripts', 'reset_prices_shopify.py'),
+    'baseprice': os.path.join('scripts', 'init_base_price.py'),
 }
 
 
@@ -48,6 +49,11 @@ def home():
 @login_required
 def percentage_updater():
     return render_template('percentage.html')
+
+@main_bp.route('/base-price-init')
+@login_required
+def base_price_init():
+    return render_template('baseprice.html')
 
 @main_bp.route('/variant-updater', methods=['GET', 'POST'])
 @login_required
@@ -107,4 +113,11 @@ def stream_variant():
 @login_required
 def stream_reset():
     cmd = ['python3', SCRIPTS['reset']]
+    return Response(stream_job(cmd), mimetype='text/event-stream')
+
+
+@main_bp.route('/stream/baseprice')
+@login_required
+def stream_baseprice():
+    cmd = ['python3', SCRIPTS['baseprice']]
     return Response(stream_job(cmd), mimetype='text/event-stream')

--- a/webapp/templates/baseprice.html
+++ b/webapp/templates/baseprice.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3 class="mb-3"><i class="fa-solid fa-coins me-2"></i>{{ t('baseprice_title') }}</h3>
+<p>{{ t('baseprice_intro') }}</p>
+<button id="start" class="btn btn-brand">{{ t('run_baseprice') }}</button>
+<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+<pre id="log" class="mt-3" style="height:300px;overflow:auto;"></pre>
+<div id="status" class="alert alert-success d-none mt-2"></div>
+{% endblock %}
+{% block scripts %}
+<script>
+  const startBtn = document.getElementById('start');
+  const spinner = document.getElementById('spinner');
+  const status = document.getElementById('status');
+  startBtn.onclick = function(){
+    const log = document.getElementById('log');
+    log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
+    const es = new EventSource('/stream/baseprice');
+    es.onmessage = e => {
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        status.textContent = "{{ t('baseprice_completed') }}";
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\n';
+      }
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+</script>
+{% endblock %}

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -21,5 +21,14 @@
       </div>
     </a>
   </div>
+  <div class="col-md-6 col-lg-4">
+    <a href="{{ url_for('main.base_price_init') }}" class="text-decoration-none text-reset">
+      <div class="card service-card h-100 text-center p-4">
+        <i class="fa-solid fa-coins fa-2x mb-3"></i>
+        <h5 class="card-title">{{ t('baseprice_card_title') }}</h5>
+        <p class="card-text small">{{ t('baseprice_card_desc') }}</p>
+      </div>
+    </a>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Provide a new script and web UI to initialize `base_price` metafields across all products
- Add translations, routes, and home card for running the base price initializer
- Allow disabling CSRF with the `WTF_CSRF_ENABLED` env var for testing

## Testing
- `ADMIN_USERNAME=admin ADMIN_PASSWORD=password WTF_CSRF_ENABLED=false PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f556c0c408328acb47acc11daa08a