### PR TITLE
Use current interpreter for stream subprocesses

### DIFF
--- a/tests/test_stream_endpoints.py
+++ b/tests/test_stream_endpoints.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import pytest
+from webapp import create_app
+from webapp import routes as routes_mod
+
+
+@pytest.fixture
+def app():
+    os.environ['SECRET_KEY'] = 'test-key'
+    os.environ['ADMIN_USERNAME'] = 'admin'
+    os.environ['ADMIN_PASSWORD'] = 'password'
+    app = create_app()
+    app.config['TESTING'] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'username': 'admin', 'password': 'password'})
+
+
+def setup_patches(monkeypatch):
+    captured = {}
+
+    def fake_enqueue(cmd):
+        captured['cmd'] = cmd
+        return 'job'
+
+    def fake_stream(job_id):
+        if False:
+            yield None
+
+    monkeypatch.setattr(routes_mod, 'enqueue', fake_enqueue)
+    monkeypatch.setattr(routes_mod, 'stream', fake_stream)
+    return captured
+
+
+def test_stream_percentage_uses_sys_executable(client, monkeypatch):
+    captured = setup_patches(monkeypatch)
+    login(client)
+    resp = client.get('/stream/percentage?percent=5')
+    assert resp.status_code == 200
+    assert captured['cmd'][0] == sys.executable
+    assert captured['cmd'][1] == routes_mod.SCRIPTS['percentage']
+    assert captured['cmd'][2:] == ['--percent', '5']
+
+
+def test_stream_variant_uses_sys_executable(client, monkeypatch):
+    captured = setup_patches(monkeypatch)
+    login(client)
+    resp = client.get('/stream/variant')
+    assert resp.status_code == 200
+    assert captured['cmd'] == [sys.executable, routes_mod.SCRIPTS['variant']]
+
+
+def test_stream_reset_uses_sys_executable(client, monkeypatch):
+    captured = setup_patches(monkeypatch)
+    login(client)
+    resp = client.get('/stream/reset')
+    assert resp.status_code == 200
+    assert captured['cmd'] == [sys.executable, routes_mod.SCRIPTS['reset']]
+
+
+def test_stream_baseprice_uses_sys_executable(client, monkeypatch):
+    captured = setup_patches(monkeypatch)
+    login(client)
+    resp = client.get('/stream/baseprice')
+    assert resp.status_code == 200
+    assert captured['cmd'] == [sys.executable, routes_mod.SCRIPTS['baseprice']]

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -10,6 +10,7 @@ from flask import (
 )
 import os
 import json
+import sys
 
 from .jobqueue import enqueue, stream
 from . import translate
@@ -99,25 +100,25 @@ def stream_percentage():
     percent = request.args.get('percent')
     if not percent:
         return 'Missing percent', 400
-    cmd = ['python3', SCRIPTS['percentage'], '--percent', percent]
+    cmd = [sys.executable, SCRIPTS['percentage'], '--percent', percent]
     return Response(stream_job(cmd), mimetype='text/event-stream')
 
 @main_bp.route('/stream/variant')
 @login_required
 def stream_variant():
-    cmd = ['python3', SCRIPTS['variant']]
+    cmd = [sys.executable, SCRIPTS['variant']]
     return Response(stream_job(cmd), mimetype='text/event-stream')
 
 
 @main_bp.route('/stream/reset')
 @login_required
 def stream_reset():
-    cmd = ['python3', SCRIPTS['reset']]
+    cmd = [sys.executable, SCRIPTS['reset']]
     return Response(stream_job(cmd), mimetype='text/event-stream')
 
 
 @main_bp.route('/stream/baseprice')
 @login_required
 def stream_baseprice():
-    cmd = ['python3', SCRIPTS['baseprice']]
+    cmd = [sys.executable, SCRIPTS['baseprice']]
     return Response(stream_job(cmd), mimetype='text/event-stream')


### PR DESCRIPTION
## Summary
- ensure webapp stream endpoints invoke scripts with the same Python interpreter running the app
- add tests verifying each streaming endpoint uses `sys.executable`

## Testing
- `WTF_CSRF_ENABLED=false PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc7349fd48328bf02b3905d5aa0cb