### PR TITLE
Ensure base price script uses UTF-8 stdout

### DIFF
--- a/scripts/init_base_price.py
+++ b/scripts/init_base_price.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import os
+import sys
 
 import time
 import requests
 from dotenv import load_dotenv
 
 load_dotenv()
+sys.stdout.reconfigure(encoding="utf-8")
 TOKEN       = os.getenv("API_TOKEN")
 DOMAIN      = os.getenv("SHOP_DOMAIN")
 API_VERSION = os.getenv("API_VERSION", "2024-04")


### PR DESCRIPTION
## Summary
- Configure `init_base_price.py` to emit UTF-8 text so emoji characters print reliably

## Testing
- `PYTHONPATH=. pytest -q` *(fails: assert resp.status_code == 200, ...)*

------
https://chatgpt.com/codex/tasks/task_e_689fc922e6e08328ba9867c9bac25421