### PR TITLE
Add ensemble price updater and streaming UI

### DIFF
--- a/scripts/update_ensemble_prices.py
+++ b/scripts/update_ensemble_prices.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import os
+import json
+import time
+import requests
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+TOKEN = os.getenv("API_TOKEN")
+DOMAIN = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+
+
+def shopify_get(session, url, **kwargs):
+    """GET request with basic retry handling."""
+    while True:
+        resp = session.get(url, timeout=30, **kwargs)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def graphql_post(session, query, variables=None):
+    """POST to Shopify GraphQL with retry on rate limits."""
+    url = f"https://{DOMAIN}/admin/api/{API_VERSION}/graphql.json"
+    payload = {"query": query, "variables": variables or {}}
+    while True:
+        resp = session.post(url, json=payload, timeout=30)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def round_to_tidy(price: float) -> str:
+    price_int = int(round(price))
+    rem = price_int % 100
+    base = price_int - rem
+    opts = [base, base + 90, base + 100]
+    tidy = min(opts, key=lambda x: abs(price_int - x))
+    return f"{tidy:.2f}"
+
+
+def main():
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": TOKEN,
+        "Content-Type": "application/json",
+    })
+
+    sur_path = os.path.join(os.path.dirname(__file__), "..", "tempo solution", "variant_prices.json")
+    with open(sur_path, encoding="utf-8") as f:
+        surcharges = json.load(f)
+
+    base_url = f"https://{DOMAIN}/admin/api/{API_VERSION}"
+
+    updates_by_product = {}
+    total = 0
+    page_info = None
+    while True:
+        params = {"limit": 250, "fields": "id,tags,variants"}
+        if page_info:
+            params["page_info"] = page_info
+        resp = shopify_get(session, f"{base_url}/products.json", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+        for prod in data.get("products", []):
+            if "ensemble" not in prod.get("tags", ""):
+                continue
+            pid = prod["id"]
+            base_price = float(prod["variants"][0]["price"])
+            for v in prod["variants"]:
+                collier = v.get("option1", "")
+                bracelet = v.get("option2", "")
+                price = base_price
+                price += surcharges["colliers"].get(collier, 0)
+                price += surcharges["bracelets"].get(bracelet, 0)
+                tidy = round_to_tidy(price)
+                updates_by_product.setdefault(pid, [])
+                updates_by_product[pid].append({
+                    "id": f"gid://shopify/ProductVariant/{v['id']}",
+                    "price": tidy,
+                })
+                total += 1
+
+        link = resp.headers.get("Link", "")
+        if 'rel="next"' not in link:
+            break
+        page_info = link.split("page_info=")[1].split(">")[0]
+
+    mutation = """
+    mutation BulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+      productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+        userErrors { field message }
+      }
+    }
+    """
+
+    for pid, updates in updates_by_product.items():
+        for i in range(0, len(updates), 50):
+            batch = updates[i:i+50]
+            resp = graphql_post(session, mutation, {
+                "productId": f"gid://shopify/Product/{pid}",
+                "variants": batch,
+            })
+            if resp.ok:
+                errs = resp.json()["data"]["productVariantsBulkUpdate"]["userErrors"]
+                if errs:
+                    for e in errs:
+                        print(f"[ERROR] {e['field']}: {e['message']}")
+                for u in batch:
+                    print(f"[OK] {u['id'].split('/')[-1]} → {u['price']}")
+            else:
+                print(f"[ERROR] bulk update failed: {resp.text}")
+
+    print(f"[DONE] Updated {total} variants")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_stream_endpoints.py
+++ b/tests/test_stream_endpoints.py
@@ -73,3 +73,11 @@ def test_stream_baseprice_uses_sys_executable(client, monkeypatch):
     resp = client.get('/stream/baseprice')
     assert resp.status_code == 200
     assert captured['cmd'] == [sys.executable, routes_mod.SCRIPTS['baseprice']]
+
+
+def test_stream_ensemble_uses_sys_executable(client, monkeypatch):
+    captured = setup_patches(monkeypatch)
+    login(client)
+    resp = client.get('/stream/ensemble')
+    assert resp.status_code == 200
+    assert captured['cmd'] == [sys.executable, routes_mod.SCRIPTS['ensemble']]

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -75,6 +75,18 @@ TRANSLATIONS = {
         'en': 'Initialization completed!',
         'fr': 'Initialisation terminée !'
     },
+    'ensemble_intro': {
+        'en': 'Compute ensemble variant prices and push updates to Shopify.',
+        'fr': 'Calculer les prix des variantes ensemble et envoyer les mises à jour à Shopify.'
+    },
+    'run_ensemble': {
+        'en': 'Run Ensemble Update',
+        'fr': 'Exécuter la mise à jour ensemble'
+    },
+    'ensemble_completed': {
+        'en': 'Ensemble update completed!',
+        'fr': 'Mise à jour des ensembles terminée !'
+    },
     'ensemble': {'en': 'Ensemble', 'fr': 'Ensemble'},
     'ensemble_card_title': {'en': 'Ensemble Products', 'fr': 'Produits Ensemble'},
     'ensemble_card_desc': {

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -31,6 +31,8 @@ SCRIPTS = {
 
     'baseprice': os.path.join('scripts', 'init_base_price.py'),
 
+    'ensemble': os.path.join('scripts', 'update_ensemble_prices.py'),
+
 }
 
 
@@ -59,34 +61,10 @@ def base_price_init():
     return render_template('baseprice.html')
 
 
-@main_bp.route('/ensemble', methods=['GET', 'POST'])
+@main_bp.route('/ensemble')
 @login_required
 def ensemble_pricing():
-    file_path = os.path.join('tempo solution', 'variant_prices.json')
-    with open(file_path, encoding='utf-8') as f:
-        surcharges = json.load(f)
-
-    price = None
-    collier = bracelet = ''
-    base_price = ''
-    if request.method == 'POST':
-        base_price = request.form.get('base_price', '').strip()
-        collier = request.form.get('collier')
-        bracelet = request.form.get('bracelet')
-        try:
-            price = float(base_price)
-            price += surcharges['colliers'].get(collier, 0)
-            price += surcharges['bracelets'].get(bracelet, 0)
-        except ValueError:
-            flash(translate('invalid_value', chain='price'), 'error')
-    return render_template(
-        'ensemble.html',
-        surcharges=surcharges,
-        price=price,
-        collier=collier,
-        bracelet=bracelet,
-        base_price=base_price,
-    )
+    return render_template('ensemble.html')
 
 @main_bp.route('/variant-updater', methods=['GET', 'POST'])
 @login_required
@@ -151,4 +129,11 @@ def stream_reset():
 @login_required
 def stream_baseprice():
     cmd = [sys.executable, SCRIPTS['baseprice']]
+    return Response(stream_job(cmd), mimetype='text/event-stream')
+
+
+@main_bp.route('/stream/ensemble')
+@login_required
+def stream_ensemble():
+    cmd = [sys.executable, SCRIPTS['ensemble']]
     return Response(stream_job(cmd), mimetype='text/event-stream')

--- a/webapp/templates/ensemble.html
+++ b/webapp/templates/ensemble.html
@@ -1,30 +1,37 @@
 {% extends 'base.html' %}
 {% block content %}
-<h3 class="mb-4">{{ t('ensemble_title') }}</h3>
-<form method="post" class="mb-3">
-  <div class="mb-3">
-    <label class="form-label">{{ t('base_price_label') }}</label>
-    <input type="number" step="0.01" class="form-control" name="base_price" value="{{ base_price }}" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">{{ t('collier_label') }}</label>
-    <select class="form-select" name="collier">
-      {% for name, price in surcharges['colliers'].items() %}
-      <option value="{{ name }}" {% if name==collier %}selected{% endif %}>{{ name }} ({{ price }})</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">{{ t('bracelet_label') }}</label>
-    <select class="form-select" name="bracelet">
-      {% for name, price in surcharges['bracelets'].items() %}
-      <option value="{{ name }}" {% if name==bracelet %}selected{% endif %}>{{ name }} ({{ price }})</option>
-      {% endfor %}
-    </select>
-  </div>
-  <button class="btn btn-primary" type="submit">{{ t('calculate') }}</button>
-</form>
-{% if price is not none %}
-<div class="alert alert-info">{{ t('total_price') }}: {{ price }}</div>
-{% endif %}
+<h3 class="mb-3"><i class="fa-solid fa-coins me-2"></i>{{ t('ensemble_title') }}</h3>
+<p>{{ t('ensemble_intro') }}</p>
+<button id="start" class="btn btn-brand">{{ t('run_ensemble') }}</button>
+<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
+<pre id="log" class="mt-3" style="height:300px;overflow:auto;"></pre>
+<div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
+{% block scripts %}
+<script>
+  const startBtn = document.getElementById('start');
+  const spinner = document.getElementById('spinner');
+  const status = document.getElementById('status');
+  startBtn.onclick = function(){
+    const log = document.getElementById('log');
+    log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
+    const es = new EventSource('/stream/ensemble');
+    es.onmessage = e => {
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        status.textContent = "{{ t('ensemble_completed') }}";
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\n';
+      }
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- compute and bulk update prices for `ensemble` products using collier and bracelet surcharges
- expose new `/stream/ensemble` endpoint and UI to run the job with live logs
- add translations and tests for the new functionality

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2dbbb43e88328ae73f297b590fccc