### PR TITLE
Sync base price metafield updates with product price

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,69 @@
+import os
+import json
+import hmac
+import hashlib
+import base64
+import pytest
+
+from webapp import create_app
+from webapp import webhook as webhook_mod
+
+
+def _sign(body: bytes) -> str:
+    secret = os.environ['SHOPIFY_WEBHOOK_SECRET'].encode()
+    digest = hmac.new(secret, body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+@pytest.fixture
+def app():
+    os.environ['SECRET_KEY'] = 'test'
+    os.environ['WTF_CSRF_ENABLED'] = 'false'
+    os.environ['SHOPIFY_WEBHOOK_SECRET'] = 'shhh'
+    os.environ['API_TOKEN'] = 'token'
+    os.environ['SHOP_DOMAIN'] = 'example.myshopify.com'
+    app = create_app()
+    app.config['TESTING'] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_webhook_triggers_update(monkeypatch, client):
+    called = {}
+
+    def fake_update(pid, price):
+        called['pid'] = pid
+        called['price'] = price
+
+    monkeypatch.setattr(webhook_mod, '_update_variant_prices', fake_update)
+
+    payload = {
+        'namespace': 'custom',
+        'key': 'base_price',
+        'owner_id': 42,
+        'value': '19.99',
+    }
+    body = json.dumps(payload).encode()
+    hmac_header = _sign(body)
+    resp = client.post(
+        '/webhook/metafield',
+        data=body,
+        headers={'Content-Type': 'application/json', 'X-Shopify-Hmac-SHA256': hmac_header},
+    )
+    assert resp.status_code == 200
+    assert called == {'pid': 42, 'price': '19.99'}
+
+
+def test_webhook_invalid_hmac(client):
+    payload = {'namespace': 'custom', 'key': 'base_price', 'owner_id': 1, 'value': '9'}
+    body = json.dumps(payload).encode()
+    resp = client.post(
+        '/webhook/metafield',
+        data=body,
+        headers={'Content-Type': 'application/json', 'X-Shopify-Hmac-SHA256': 'bad'},
+    )
+    assert resp.status_code == 401

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -119,8 +119,10 @@ def create_app():
 
     from .auth import auth_bp
     from .routes import main_bp
+    from .webhook import webhook_bp
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
+    app.register_blueprint(webhook_bp)
 
     @app.before_request
     def set_language():

--- a/webapp/webhook.py
+++ b/webapp/webhook.py
@@ -1,0 +1,84 @@
+import os
+import hmac
+import hashlib
+import base64
+import requests
+from flask import Blueprint, request
+from . import csrf
+
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+
+webhook_bp = Blueprint("webhook", __name__)
+
+
+def _verify_webhook(body: bytes, hmac_header: str) -> bool:
+    secret = os.getenv("SHOPIFY_WEBHOOK_SECRET", "")
+    if not secret or not hmac_header:
+        return False
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+    computed = base64.b64encode(digest).decode()
+    return hmac.compare_digest(computed, hmac_header)
+
+
+def _shopify_session() -> requests.Session:
+    token = os.getenv("API_TOKEN")
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": token,
+        "Content-Type": "application/json",
+    })
+    return session
+
+
+def _update_variant_prices(product_id: int, price: str) -> None:
+    session = _shopify_session()
+    domain = os.getenv("SHOP_DOMAIN")
+    base_url = f"https://{domain}/admin/api/{API_VERSION}"
+    resp = session.get(f"{base_url}/products/{product_id}.json", timeout=30)
+    resp.raise_for_status()
+    variants = [v["id"] for v in resp.json().get("product", {}).get("variants", [])]
+    if not variants:
+        return
+    mutation = """
+    mutation BulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+      productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+        userErrors { field message }
+      }
+    }
+    """
+    variables_base = {"productId": f"gid://shopify/Product/{product_id}"}
+    chunks = [variants[i:i+50] for i in range(0, len(variants), 50)]
+    for chunk in chunks:
+        vars_payload = {
+            **variables_base,
+            "variants": [
+                {
+                    "id": f"gid://shopify/ProductVariant/{vid}",
+                    "price": price,
+                    "compareAtPrice": price,
+                }
+                for vid in chunk
+            ],
+        }
+        session.post(
+            f"https://{domain}/admin/api/{API_VERSION}/graphql.json",
+            json={"query": mutation, "variables": vars_payload},
+            timeout=30,
+        )
+
+
+@webhook_bp.route("/webhook/metafield", methods=["POST"])
+@csrf.exempt
+def metafield_update():
+    if not _verify_webhook(request.data, request.headers.get("X-Shopify-Hmac-SHA256", "")):
+        return "Unauthorized", 401
+    data = request.get_json() or {}
+    if data.get("namespace") == "custom" and data.get("key") == "base_price":
+        price = str(data.get("value"))
+        product_id = data.get("owner_id")
+        try:
+            _update_variant_prices(product_id, price)
+        except Exception as exc:
+            print(f"Webhook error: {exc}")
+            return "", 500
+    return "", 200


### PR DESCRIPTION
## Summary
- register webhook blueprint
- handle base_price metafield update and sync variant prices
- test base_price webhook and HMAC validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2e40a61108328a6de2aab355110e3