### PR TITLE
Add metafield webhook registration script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ API_VERSION=2024-04
 ADMIN_USERNAME=youruser
 ADMIN_PASSWORD=yourpass
 SECRET_KEY=change-me
+APP_BASE_URL=https://example.com

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains tools to update Shopify variant prices and now includes
    ADMIN_USERNAME=youruser
    ADMIN_PASSWORD=yourpass
    SECRET_KEY=random-string
+   APP_BASE_URL=https://example.com
    ```
 3. Start the server (set `DEBUG=true` in your environment to enable Flask debug
    mode):
@@ -50,6 +51,27 @@ ignored by Git and will be recreated whenever needed. The update and reset
 scripts now use Shopify's `productVariantsBulkUpdate(productId: ID!, variants:
 [ProductVariantsBulkInput!]!)` mutation to push prices back in batches of up to
 50 variants per product for faster recovery.
+
+## Shopify Webhook Setup
+
+Register a webhook so Shopify notifies the app when a product's
+`custom.base_price` metafield changes.
+
+1. Expose your running app at a public URL and set `APP_BASE_URL` in your
+   environment to that root (for example `https://example.com`).
+2. Initialize the `base_price` metafield for all products if you haven't
+   already:
+   ```bash
+   python scripts/init_base_price.py
+   ```
+3. Register the webhook:
+   ```bash
+   python scripts/register_metafield_webhook.py
+   ```
+4. (Optional) Align all existing prices with their `base_price` metafield:
+   ```bash
+   python scripts/sync_prices_from_base.py
+   ```
 
 ## Deploying in Production
 

--- a/scripts/register_metafield_webhook.py
+++ b/scripts/register_metafield_webhook.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TOKEN = os.getenv("API_TOKEN")
+DOMAIN = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+APP_BASE_URL = os.getenv("APP_BASE_URL")
+
+if not APP_BASE_URL:
+    print("APP_BASE_URL is not set")
+    sys.exit(1)
+
+
+def shopify_request(session, method, url, **kwargs):
+    while True:
+        resp = session.request(method, url, timeout=30, **kwargs)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def main():
+    session = requests.Session()
+    session.headers.update(
+        {
+            "X-Shopify-Access-Token": TOKEN,
+            "Content-Type": "application/json",
+        }
+    )
+    base_url = f"https://{DOMAIN}/admin/api/{API_VERSION}"
+    address = f"{APP_BASE_URL.rstrip('/')}/webhook/metafield"
+
+    # Check existing webhooks
+    resp = shopify_request(
+        session,
+        "get",
+        f"{base_url}/webhooks.json",
+        params={"topic": "metafields/update"},
+    )
+    if resp.ok:
+        for hook in resp.json().get("webhooks", []):
+            if hook.get("address") == address:
+                print(f"[OK] Webhook already registered (id={hook.get('id')})")
+                return
+
+    payload = {
+        "webhook": {
+            "topic": "metafields/update",
+            "address": address,
+            "format": "json",
+        }
+    }
+    resp = shopify_request(
+        session, "post", f"{base_url}/webhooks.json", json=payload
+    )
+    if resp.ok:
+        wid = resp.json().get("webhook", {}).get("id")
+        print(f"[OK] Registered webhook (id={wid})")
+    else:
+        print(f"[ERROR] {resp.status_code} {resp.text}")
+        resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document environment variable for app's public URL
- add script to register a Shopify metafield webhook targeting `/webhook/metafield`
- update README with webhook setup instructions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9230152e48328a6eeae384eaf3289