### PR TITLE
Handle Shopify variant update errors

### DIFF
--- a/webapp/webhook.py
+++ b/webapp/webhook.py
@@ -60,11 +60,16 @@ def _update_variant_prices(product_id: int, price: str) -> None:
                 for vid in chunk
             ],
         }
-        session.post(
+        resp = session.post(
             f"https://{domain}/admin/api/{API_VERSION}/graphql.json",
             json={"query": mutation, "variables": vars_payload},
             timeout=30,
         )
+        resp.raise_for_status()
+        data = resp.json().get("data", {})
+        errors = data.get("productVariantsBulkUpdate", {}).get("userErrors")
+        if errors:
+            raise Exception(f"Bulk update errors: {errors}")
 
 
 @webhook_bp.route("/webhook/metafield", methods=["POST"])


### PR DESCRIPTION
## Summary
- capture GraphQL response when updating variant prices
- surface userErrors by raising an exception

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92989509c832890faeae14a8e1741