### PR TITLE
Handle metafield webhook registration errors

### DIFF
--- a/scripts/register_metafield_webhook.py
+++ b/scripts/register_metafield_webhook.py
@@ -65,7 +65,20 @@ def main():
         print(f"[OK] Registered webhook (id={wid})")
     else:
         print(f"[ERROR] {resp.status_code} {resp.text}")
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            errors = {}
+            try:
+                errors = resp.json().get("errors", {})
+            except ValueError:
+                pass
+            topic_error = errors.get("topic")
+            if topic_error:
+                print(
+                    f"[INFO] {topic_error} — ensure the app has required scopes (e.g., read/write_metafields)"
+                )
+            raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Handle HTTP errors when registering metafield webhook
- Report missing scope details and re-raise the HTTP error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a93444ee68832880535cd51e4a7a8e