### PR TITLE
Add metaobject webhook support for base price updates

### DIFF
--- a/scripts/create_base_price_metaobject.py
+++ b/scripts/create_base_price_metaobject.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import os
+import time
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TOKEN = os.getenv("API_TOKEN")
+DOMAIN = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+
+
+def graphql_request(session, query, variables=None):
+    url = f"https://{DOMAIN}/admin/api/{API_VERSION}/graphql.json"
+    payload = {"query": query, "variables": variables or {}}
+    while True:
+        resp = session.post(url, json=payload, timeout=30)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+
+def main():
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": TOKEN,
+        "Content-Type": "application/json",
+    })
+
+    mutation = """
+    mutation CreateDef($def: MetaobjectDefinitionCreateInput!) {
+      metaobjectDefinitionCreate(definition: $def) {
+        metaobjectDefinition { id }
+        userErrors { field message }
+      }
+    }
+    """
+    variables = {
+        "def": {
+            "name": "base_price",
+            "type": "base_price",
+            "fieldDefinitions": [
+                {
+                    "name": "Product",
+                    "key": "product",
+                    "type": "reference",
+                    "referenceType": "PRODUCT",
+                },
+                {
+                    "name": "Price",
+                    "key": "price",
+                    "type": "number_decimal",
+                },
+            ],
+        }
+    }
+
+    resp = graphql_request(session, mutation, variables)
+    if resp.ok:
+        data = resp.json().get("data", {}).get("metaobjectDefinitionCreate", {})
+        errs = data.get("userErrors")
+        if errs:
+            print("[ERROR]", errs)
+        else:
+            mid = data.get("metaobjectDefinition", {}).get("id")
+            print(f"[OK] Definition created (id={mid})")
+    else:
+        print(f"[ERROR] {resp.status_code} {resp.text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/register_metaobject_webhook.py
+++ b/scripts/register_metaobject_webhook.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TOKEN = os.getenv("API_TOKEN")
+DOMAIN = os.getenv("SHOP_DOMAIN")
+API_VERSION = os.getenv("API_VERSION", "2024-04")
+APP_BASE_URL = os.getenv("APP_BASE_URL")
+
+if not APP_BASE_URL:
+    print("APP_BASE_URL is not set")
+    sys.exit(1)
+
+
+def shopify_request(session, method, url, **kwargs):
+    while True:
+        resp = session.request(method, url, timeout=30, **kwargs)
+        if resp.status_code == 429:
+            time.sleep(2)
+            continue
+        return resp
+
+def main():
+    session = requests.Session()
+    session.headers.update({
+        "X-Shopify-Access-Token": TOKEN,
+        "Content-Type": "application/json",
+    })
+    base_url = f"https://{DOMAIN}/admin/api/{API_VERSION}"
+    address = f"{APP_BASE_URL.rstrip('/')}/webhook/metaobject"
+
+    resp = shopify_request(
+        session,
+        "get",
+        f"{base_url}/webhooks.json",
+        params={"topic": "metaobjects/update"},
+    )
+    if resp.ok:
+        for hook in resp.json().get("webhooks", []):
+            if hook.get("address") == address:
+                print(f"[OK] Webhook already registered (id={hook.get('id')})")
+                return
+
+    payload = {
+        "webhook": {
+            "topic": "metaobjects/update",
+            "address": address,
+            "format": "json",
+        }
+    }
+    resp = shopify_request(
+        session, "post", f"{base_url}/webhooks.json", json=payload
+    )
+    if resp.ok:
+        wid = resp.json().get("webhook", {}).get("id")
+        print(f"[OK] Registered webhook (id={wid})")
+    else:
+        print(f"[ERROR] {resp.status_code} {resp.text}")
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError:
+            raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define `base_price` metaobject with product reference and decimal price
- script to register `metaobjects/update` webhook pointing to `/webhook/metaobject`
- handle `metaobject` webhook in Flask app and test that variant prices update

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8382da9708328937e991f0253cd7c