### PR TITLE
Update product query to fetch variant price scalar

### DIFF
--- a/scripts/init_base_price_metaobject.py
+++ b/scripts/init_base_price_metaobject.py
@@ -72,9 +72,7 @@ query Products($cursor: String) {
         variants(first: 1) {
           edges {
             node {
-              price {
-                amount
-              }
+              price
             }
           }
         }


### PR DESCRIPTION
## Summary
- update the product query to request the variant price scalar field

## Testing
- python scripts/init_base_price_metaobject.py

------
https://chatgpt.com/codex/tasks/task_e_68c849f461608328b0216e5fcd2cf46c