### PR TITLE
Update base price metaobject query owner parameter

### DIFF
--- a/scripts/init_base_price_metaobject.py
+++ b/scripts/init_base_price_metaobject.py
@@ -114,8 +114,8 @@ def fetch_products(session: requests.Session) -> Iterator[Dict[str, object]]:
 
 
 METAOBJECT_QUERY = """
-query BasePriceMetaobject($ownerId: ID!, $type: String!) {
-  metaobjects(first: 1, ownerId: $ownerId, type: $type) {
+query BasePriceMetaobject($owner: ID!, $type: String!) {
+  metaobjects(first: 1, type: $type, owners: [$owner]) {
     edges {
       node {
         id
@@ -127,7 +127,7 @@ query BasePriceMetaobject($ownerId: ID!, $type: String!) {
 
 
 def metaobject_exists(session: requests.Session, product_id: str) -> Optional[bool]:
-    variables = {"ownerId": product_id, "type": "base_price"}
+    variables = {"owner": product_id, "type": "base_price"}
     resp = graphql_request(session, METAOBJECT_QUERY, variables)
     data = extract_graphql_data(resp, "metaobjects")
     if data is None:


### PR DESCRIPTION
## Summary
- update the base price metaobject query to filter with the owners array parameter
- align the GraphQL variables in `metaobject_exists` with the revised query signature

## Testing
- python scripts/init_base_price_metaobject.py *(fails: Missing API token or shop domain environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c8743548328bd41a3b322f2a1eb